### PR TITLE
`\r` handling

### DIFF
--- a/src/lexing/lexer.cc
+++ b/src/lexing/lexer.cc
@@ -101,6 +101,7 @@ namespace Lexing
                 _lineBegin = &_text[_position + 1];
                 return std::nullopt;
             }
+            case '\r':
             case ' ':
                 return std::nullopt;
             


### PR DESCRIPTION
Handle `\r` like ` ` during lexing.