### PR TITLE
Added export keyword

### DIFF
--- a/framework/include/lexer/Token.h
+++ b/framework/include/lexer/Token.h
@@ -47,7 +47,7 @@ namespace lexing
         NullptrKeyword,
         StructKeyword, PrivateKeyword,
         ImportKeyword,
-        NamespaceKeyword,
+        NamespaceKeyword, ExportKeyword,
     };
 
     struct SourceLocation

--- a/framework/include/parser/Parser.h
+++ b/framework/include/parser/Parser.h
@@ -34,6 +34,7 @@ namespace parser
 {
     struct GlobalSymbol
     {
+        bool exported;
         std::string name;
         Type* type;
     };
@@ -56,6 +57,7 @@ namespace parser
 
         Scope* mScope;
         std::vector<GlobalSymbol> mSymbols;
+        bool mExportGlobal;
 
         diagnostic::Diagnostics& mDiag;
 
@@ -66,6 +68,7 @@ namespace parser
         lexing::Token peek(int offset) const;
 
         void expectToken(lexing::TokenType tokenType);
+        void expectEitherToken(std::vector<lexing::TokenType> tokenTypes);
 
         int getBinaryOperatorPrecedence(lexing::TokenType tokenType);
         int getPrefixUnaryOperatorPrecedence(lexing::TokenType tokenType);

--- a/framework/src/lexer/Lexer.cpp
+++ b/framework/src/lexer/Lexer.cpp
@@ -35,6 +35,7 @@ namespace lexing
         { "private",    TokenType::PrivateKeyword },
         { "import",     TokenType::ImportKeyword },
         { "namespace",  TokenType::NamespaceKeyword },
+        { "export",     TokenType::ExportKeyword },
     };
 
     std::vector<Token> Lexer::lex()

--- a/framework/src/lexer/Token.cpp
+++ b/framework/src/lexer/Token.cpp
@@ -130,6 +130,8 @@ namespace lexing
                 return "import";
             case TokenType::NamespaceKeyword:
                 return "namespace";
+            case TokenType::ExportKeyword:
+                return "export";
             case TokenType::Error:
                 return mText;
         }

--- a/framework/src/parser/Parser.cpp
+++ b/framework/src/parser/Parser.cpp
@@ -137,7 +137,7 @@ namespace parser
                 return parseNamespace();
             case lexing::TokenType::ExportKeyword:
                 consume();
-                expectEitherToken({ lexing::TokenType::FuncKeyword, lexing::TokenType::GlobalKeyword, lexing::TokenType::StructKeyword, lexing::TokenType::NamespaceKeyword });
+                expectEitherToken({ lexing::TokenType::FuncKeyword, lexing::TokenType::GlobalKeyword, lexing::TokenType::StructKeyword });
                 mExportGlobal = true;
                 return parseGlobal(nodes);
             default:

--- a/framework/src/parser/Parser.cpp
+++ b/framework/src/parser/Parser.cpp
@@ -32,6 +32,7 @@ namespace parser
         , mImportManager(importManager)
         , mPosition(0)
         , mScope(nullptr)
+        , mExportGlobal(false)
         , mDiag(diag)
     {
     }
@@ -61,6 +62,24 @@ namespace parser
         }
     }
 
+    void Parser::expectEitherToken(std::vector<lexing::TokenType> tokenTypes)
+    {
+        std::string tokensString;
+        for (auto& tokenType : tokenTypes)
+        {
+            if (current().getTokenType() == tokenType)
+                return;
+
+            lexing::Token temp(tokenType, {0, 0}, {0, 0});
+            tokensString += std::format("'{}{}{}', ", fmt::bold, temp.getId(), fmt::defaults);
+        }
+
+        tokensString = tokensString.substr(0, tokensString.size() - 2);
+
+        mDiag.compilerError(current().getStart(), current().getEnd(), std::format("expected either {} before '{}{}{}' token",
+            tokensString, fmt::bold, current().getId(), fmt::defaults));
+    }
+
     std::vector<ASTNodePtr> Parser::parse()
     {
         std::vector<ASTNodePtr> result;
@@ -72,6 +91,8 @@ namespace parser
             {
                 result.push_back(std::move(node));
             }
+
+            mExportGlobal = false;
         }
 
         return result;
@@ -79,6 +100,19 @@ namespace parser
 
     std::vector<GlobalSymbol> Parser::getSymbols()
     {
+        if (mExportSymbols)
+        {
+            std::vector<GlobalSymbol> res;
+
+            for (auto& symbol : mSymbols)
+            {
+                if (symbol.exported)
+                    res.push_back(symbol);
+            }
+
+            return std::move(res);
+        }
+
         return mSymbols;
     }
 
@@ -101,6 +135,11 @@ namespace parser
             }
             case lexing::TokenType::NamespaceKeyword:
                 return parseNamespace();
+            case lexing::TokenType::ExportKeyword:
+                consume();
+                expectEitherToken({ lexing::TokenType::FuncKeyword, lexing::TokenType::GlobalKeyword, lexing::TokenType::StructKeyword, lexing::TokenType::NamespaceKeyword });
+                mExportGlobal = true;
+                return parseGlobal(nodes);
             default:
                 mDiag.compilerError(current().getStart(), current().getEnd(), "Unexpected token. Expected global statement");
         }
@@ -426,7 +465,7 @@ namespace parser
             type = parseType();
         }
 
-        mSymbols.push_back({name, type});
+        mSymbols.push_back({mExportGlobal, name, type});
 
         if (current().getTokenType() == lexing::TokenType::Semicolon) // Extern function declaration
         {
@@ -481,7 +520,7 @@ namespace parser
             }
         }
         consume();
-        mSymbols.push_back({name, nullptr});
+        mSymbols.push_back({mExportGlobal, name, nullptr});
 
         mScope = scope->parent;
         mNamespaces.pop_back();
@@ -624,7 +663,7 @@ namespace parser
         expectToken(lexing::TokenType::Semicolon);
         consume();
 
-        mSymbols.push_back({name, type});
+        mSymbols.push_back({mExportGlobal, name, type});
 
         return std::make_unique<GlobalDeclaration>(std::move(name), type, std::move(initVal));
     }

--- a/hello.vpr
+++ b/hello.vpr
@@ -1,4 +1,5 @@
 namespace Hello {
+
     namespace Ball {
         export func @balls() -> void {
             return;
@@ -30,3 +31,5 @@ namespace Hello {
 export func @testing() -> void {
     return;
 }
+
+export global hey: i32 = 59;

--- a/hello.vpr
+++ b/hello.vpr
@@ -1,8 +1,12 @@
-namespace Hello {
-    namespace Qwerty {
-        func @hello() -> i32 {
-            return 69;
+export namespace Hello {
+    namespace Ball {
+        func @balls() -> void {
+            return;
         }
+    }
+
+    func @hello() -> i32 {
+        return 69;
     }
 
     struct Test {

--- a/hello.vpr
+++ b/hello.vpr
@@ -1,11 +1,11 @@
-export namespace Hello {
+namespace Hello {
     namespace Ball {
-        func @balls() -> void {
+        export func @balls() -> void {
             return;
         }
     }
 
-    func @hello() -> i32 {
+    export func @hello() -> i32 {
         return 69;
     }
 
@@ -25,4 +25,8 @@ export namespace Hello {
     func Test@method(balls: i32) -> i32 {
         return this->another + balls;
     }
+}
+
+export func @testing() -> void {
+    return;
 }

--- a/test.vpr
+++ b/test.vpr
@@ -3,14 +3,14 @@ import hello;
 func @main() -> i32 {
     let test: struct Hello::Test = struct Hello::Test { 1, 2 };
 
-    let var: i32 = Hello::hello();
+    let var: i32 = hey;
     while (true) {
         if (var + 1 == 50) continue;
         var += 1;
     }
 
     testing();
-    Test::Ball::balls();
+    Hello::Ball::balls();
 
     return test.pubMethod(var);
 }

--- a/test.vpr
+++ b/test.vpr
@@ -9,7 +9,8 @@ func @main() -> i32 {
         var += 1;
     }
 
-    Hello::Ball::balls();
+    testing();
+    Test::Ball::balls();
 
     return test.pubMethod(var);
 }

--- a/test.vpr
+++ b/test.vpr
@@ -3,11 +3,13 @@ import hello;
 func @main() -> i32 {
     let test: struct Hello::Test = struct Hello::Test { 1, 2 };
 
-    let var: i32 = Hello::Qwerty::hello();
+    let var: i32 = Hello::hello();
     while (true) {
-        if (var + 1 == 5_000) continue;
+        if (var + 1 == 50) continue;
         var += 1;
     }
+
+    Hello::Ball::balls();
 
     return test.pubMethod(var);
 }


### PR DESCRIPTION
Imports will no longer include every symbol from the imported file and will instead look for any exported symbols.
Exportable symbols are: `func`, `global` and `struct` (struct isn't implemented yet, but `export struct` is valid viper code).
Exporting is as simple as adding the keyword `export` in front of any of the previously mentioned keywords.