### PR TITLE
Fix implicit this bug

### DIFF
--- a/framework/source/parser/ast/expression/VariableExpression.cpp
+++ b/framework/source/parser/ast/expression/VariableExpression.cpp
@@ -88,7 +88,7 @@ namespace parser
         else if (auto pending = dynamic_cast<PendingStructType*>(scopeOwner))
             structType = pending->get();
 
-        if (structType)
+        if (structType && !isQualified())
         {
             auto structField = structType->getField(mNames.back());
             if (structField)


### PR DESCRIPTION
```
namespace IO {
  func print(a: i32) -> void;
}

class Test {
  private a: i32;
  private b: i32;

  public func print() -> void {
    IO::print(a);
    IO::print(b);
  }
}
```
Will now call correctly